### PR TITLE
Add travisci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - node
+  - lts/dubnium
+  - lts/carbon
+
+install:
+  - travis_retry npm install
+
+script:
+  - npm test


### PR DESCRIPTION
Resolves #28 

CI will run on `node`(v12), `lts/dubnium`(v10) & `lts/carbon`(v8).

`lts/boron`(v6) & `lts/argon`(v4) are excluded as they are already out of support. It's also causing [a lot of errors](https://travis-ci.org/josephting/stargazed/builds/599486325).

See [build result for up to `lts/carbon`](https://travis-ci.org/josephting/stargazed/builds/599487111).