### PR TITLE
Validation Tests 

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,17 +1,20 @@
 import stargazed, {
 	validate,
-	flashError,
+	// flashError,
 	htmlEscapeTable,
 	getReadmeTemplate,
 	buildReadmeContent,
-	writeReadmeContent,
+	// writeReadmeContent,
 	buildWorkflowContent,
 } from '..';
 import '@testing-library/jest-dom/extend-expect';
 
-import { inputContent, badInputToken, goodInputRepo, badInputUsername } from '../mock/contentInput';
+import { inputContent, badInputToken, goodInputValidation, badInputUsername } from '../mock/contentInput';
 
 const pckg = require('../package.json');
+
+//! flashError cannot be tested currently due to process.exit
+// ? research a way to test something as it exits?
 
 describe('Commands functional tests', () => {
 	test('should check basic input behavior of core function', async () => {
@@ -57,16 +60,28 @@ describe('Commands functional tests', () => {
 		expect(response.length > 0).toBe(true);
 	});
 	test('should check validation good input/output - positive branch return null', async () => {
-		expect(validate(goodInputRepo)).toBeNull();
+		expect(validate(goodInputValidation)).toBeNull();
 	});
 	test('should check bad inputs in validation behavior/paths', () => {
-		const badTokenRes = validate(badInputToken);
-		const fn = () => {
-			throw badTokenRes
-			}
-		expect(fn).toThrowError(new TypeError(`invalid option. Token must be a string primitive.`));
+		const badTokenRes = () => {
+			throw validate(badInputToken);
+		};
+		expect(badTokenRes).toThrowError(new TypeError(`invalid option. Token must be a string primitive.`));
+		// TODO: ADD MORE ERROR PATHS FROM validate()
+		const badUsernameRes = () => {
+			throw validate(badInputUsername);
+		};
+		expect(badUsernameRes).toThrowError(new TypeError(`invalid option. Username must be a string primitive.`));
+
+		// const badValues = () => {
+		// 	Array(7).map(e => {
+		// 		return validate(e);
+		// 	});
+		// };
 	});
+
 	// test('should ', async () => {
-	// 	console.log(writeReadmeContent());
+	// Testing this function locally affects README.md
+	// console.log(await writeReadmeContent());
 	// });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -9,7 +9,15 @@ import stargazed, {
 } from '..';
 import '@testing-library/jest-dom/extend-expect';
 
-import { inputContent, badInputToken, goodInputValidation, badInputUsername } from '../mock/contentInput';
+import {
+	inputContent,
+	badInputToken,
+	goodInputValidation,
+	badInputUsername,
+	goodInputFalseValidation,
+	badInputRepo,
+	badInputMessage,
+} from '../mock/contentInput';
 
 const pckg = require('../package.json');
 
@@ -62,26 +70,30 @@ describe('Commands functional tests', () => {
 	test('should check validation good input/output - positive branch return null', async () => {
 		expect(validate(goodInputValidation)).toBeNull();
 	});
+
+	// test('should check validation good input/output - positive branch return null', async () => {
+	// 	expect(validate(goodInputFalseValidation)).toBeNull();
+	// });
 	test('should check bad inputs in validation behavior/paths', () => {
 		const badTokenRes = () => {
 			throw validate(badInputToken);
 		};
 		expect(badTokenRes).toThrowError(new TypeError(`invalid option. Token must be a string primitive.`));
-		// TODO: ADD MORE ERROR PATHS FROM validate()
+
 		const badUsernameRes = () => {
 			throw validate(badInputUsername);
 		};
 		expect(badUsernameRes).toThrowError(new TypeError(`invalid option. Username must be a string primitive.`));
 
-		// const badValues = () => {
-		// 	Array(7).map(e => {
-		// 		return validate(e);
-		// 	});
-		// };
+		const badRepoRes = () => {
+			throw validate(badInputRepo);
+		};
+		expect(badRepoRes).toThrowError(new TypeError('invalid option. Repo name must be a string primitive.'));
+		const badMessageRes = () => {
+			throw validate(badInputMessage);
+		};
+		expect(badMessageRes).toThrowError(new TypeError('invalid option. Commit message must be a string primitive.'));
 	});
 
-	// test('should ', async () => {
-	// Testing this function locally affects README.md
-	// console.log(await writeReadmeContent());
-	// });
+	
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,4 @@
-<<<<<<< HEAD
+import '@testing-library/jest-dom/extend-expect';
 import stargazed, {
 	validate,
 	// flashError,
@@ -8,23 +8,16 @@ import stargazed, {
 	// writeReadmeContent,
 	buildWorkflowContent,
 } from '..';
-import '@testing-library/jest-dom/extend-expect';
 
 import {
 	inputContent,
 	badInputToken,
 	goodInputValidation,
 	badInputUsername,
-	goodInputFalseValidation,
+	// goodInputFalseValidation,
 	badInputRepo,
 	badInputMessage,
 } from '../mock/contentInput';
-=======
-import stargazed, { validate, htmlEscapeTable, getReadmeTemplate, buildReadmeContent, buildWorkflowContent } from '..';
-import '@testing-library/jest-dom/extend-expect';
-
-import { inputContent, badInputToken, goodInputRepo } from '../mock/contentInput';
->>>>>>> 6b70a9eaee07d41ea11b9893426977654cddd9d3
 
 const pckg = require('../package.json');
 
@@ -101,6 +94,4 @@ describe('Commands functional tests', () => {
 		};
 		expect(badMessageRes).toThrowError(new TypeError('invalid option. Commit message must be a string primitive.'));
 	});
-
-	
 });

--- a/mock/contentInput.js
+++ b/mock/contentInput.js
@@ -11,6 +11,25 @@ export const inputContent = {
 	date: `${new Date().getDate()}--${new Date().getMonth()}--${new Date().getFullYear()}`,
 };
 
+export const goodInputValidation = {
+	username: 'Jean-Luc-Picard',
+	token: '1701-D',
+	repo: 'Enterprise',
+	message: 'Make it so...',
+	sort: true,
+	workflow: true,
+	version: true,
+};
+export const goodInputFalseValidation = {
+	username: 'Jean-Luc-Picard',
+	token: '1701-D',
+	repo: 'Enterprise',
+	message: 'Make it so...',
+	sort: false,
+	workflow: false,
+	version: false,
+};
+
 export const badInputToken = {
 	username: 'Jean-Luc-Picard',
 	token: null,
@@ -31,11 +50,20 @@ export const badInputUsername = {
 	version: true,
 };
 
-export const goodInputValidation = {
-	username: 'Jean-Luc-Picard',
+export const badInputRepo = {
+	username: 'Jean Luc Picard',
+	token: '1701-D',
+	repo: null,
+	message: 'Make it so...',
+	sort: true,
+	workflow: true,
+	version: true,
+};
+export const badInputMessage = {
+	username: 'Jean Luc Picard',
 	token: '1701-D',
 	repo: 'Enterprise',
-	message: 'Make it so...',
+	message: null,
 	sort: true,
 	workflow: true,
 	version: true,

--- a/mock/contentInput.js
+++ b/mock/contentInput.js
@@ -31,7 +31,7 @@ export const badInputUsername = {
 	version: true,
 };
 
-export const goodInputRepo = {
+export const goodInputValidation = {
 	username: 'Jean-Luc-Picard',
 	token: '1701-D',
 	repo: 'Enterprise',


### PR DESCRIPTION
- All branches tested except false flags options
    - `false` currently throws an error that it's not a primitive boolean. It is very likely `isBoolean` 
is not correctly checking the type, using the JS builtin operator `typeof === 'boolean` is probably more **performant** anyways.  